### PR TITLE
Scripts fixes: Fixed `docker compose` compatibility issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Keep in mind that the port in the template is hard-coded to `3000`, but it can b
 
 E.g.
 ```
-sed -i "s/NGINX_HOSTNAME:.*/NGINX_HOSTNAME:5000/" data/nginx/sites.template-local
+sed -i "s/DOMAIN_NAME:.*/DOMAIN_NAME:5000/" data/nginx/sites.template-local
 ```
 
 When keycloak is initialized, it also needs to be configured by adding a, and then set those values into the `data/greenlight/.env` file.

--- a/data/greenlight/bin/start
+++ b/data/greenlight/bin/start
@@ -9,14 +9,14 @@ echo "Web app starting on port: $PORT"
 db_create="$(RAILS_ENV=$RAILS_ENV bundle exec rake db:create 2>&1)"
 echo $db_create
 
-if [[ $db_create == *"already exists"* ]]; then
-  echo ">>> Database migration"
-  bundle exec rake db:migrate:with_data
-else
+rails assets:precompile
+
+if [[ $db_create != *"already exists"* ]]; then
   echo ">>> Database initialization"
   bundle exec rake db:schema:load
 fi
 
-rails assets:precompile
+echo ">>> Database migration"
+bundle exec rake db:migrate:with_data
 
 rails s -b 0.0.0.0 -p $PORT

--- a/data/greenlight/dotenv
+++ b/data/greenlight/dotenv
@@ -1,31 +1,33 @@
-# POSTGRES DATABASE URL
+### POSTGRES DATABASE URL
 # Must be in the format postgres://username:password@host:port
 #   E.g. postgres://postgres:password@postgres:5432
 DATABASE_URL=
-
-# REDIS CACHE URL
+#
+### REDIS CACHE URL
 # Must be in the format redis://host:port
 #   E.g. redis://redis:6379
-REDIS_URL=
-
-# The endpoint and secret for your BigBlueButton server.
+REDIS_URL=redis://redis:6379
+#
+### The endpoint and secret for your BigBlueButton server.
 # Set these if you are running GreenLight on a single BigBlueButton server.
 # You can retrive these by running the following command on your BigBlueButton server:
 #
 #   bbb-conf --secret
 #
-BIGBLUEBUTTON_ENDPOINT=https://test-install.blindsidenetworks.com/bigbluebutton/
+BIGBLUEBUTTON_ENDPOINT=https://test-install.blindsidenetworks.com/bigbluebutton/api
 BIGBLUEBUTTON_SECRET=8cd8ef52e8e101574e400365b55e11a6
-
-SECRET_KEY_BASE=secret
-
-# PORT=3000
-# RAILS_ENV=production
-# RAILS_SERVE_STATIC_FILES=true
-
+#
+### GL3 secret key base.
+# openssl rand -hex 64openssl rand -hex 64
+SECRET_KEY_BASE=
+#
+#PORT=3000
+#RAILS_ENV=production
+#RAILS_SERVE_STATIC_FILES=true
+#
 RAILS_LOG_TO_STDOUT=true
-
-# OPENID_CONNECT_CLIENT_ID=
-# OPENID_CONNECT_CLIENT_SECRET=
-# OPENID_CONNECT_ISSUER=
-# OPENID_CONNECT_REDIRECT=
+#
+#OPENID_CONNECT_CLIENT_ID=
+#OPENID_CONNECT_CLIENT_SECRET=
+#OPENID_CONNECT_ISSUER=
+#OPENID_CONNECT_REDIRECT=

--- a/data/nginx/sites-common/acme_challenge.conf
+++ b/data/nginx/sites-common/acme_challenge.conf
@@ -1,0 +1,7 @@
+#####################################################
+### FOR ACME CHALLENGES
+location ^~ /.well-known/acme-challenge/ {
+    alias /var/www/certbot/.well-known/acme-challenge/;
+}
+### END ACME CHALLENGES
+#####################################################

--- a/data/nginx/sites-common/proxy.conf
+++ b/data/nginx/sites-common/proxy.conf
@@ -10,4 +10,4 @@ proxy_set_header  X-Forwarded-Proto $scheme;
 
 proxy_http_version 1.1;
 proxy_set_header Upgrade $http_upgrade;
-proxy_set_header Connection "upgrade";
+proxy_set_header Connection "Upgrade";

--- a/data/nginx/sites.template-docker
+++ b/data/nginx/sites.template-docker
@@ -5,6 +5,7 @@ upstream greenlight-server {
 }
 
 server {
+    include    /etc/nginx/sites-common/acme_challenge.conf;
     server_name $GL_HOSTNAME.$DOMAIN_NAME;
 
     listen 80;
@@ -71,6 +72,7 @@ upstream keycloak-server {
 }
 
 server {
+    include    /etc/nginx/sites-common/acme_challenge.conf;
     server_name $KC_HOSTNAME.$DOMAIN_NAME;
 
     listen 80;

--- a/data/nginx/sites.template-docker
+++ b/data/nginx/sites.template-docker
@@ -1,19 +1,19 @@
-#### For <gl.$NGINX_HOSTNAME>
+#### For <$GL_HOSTNAME.$DOMAIN_NAME>
 
 upstream greenlight-server {
     server greenlight:3000;
 }
 
 server {
-    server_name gl.$NGINX_HOSTNAME;
+    server_name $GL_HOSTNAME.$DOMAIN_NAME;
 
     listen 80;
     listen [::]:80;
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    ssl_certificate /etc/letsencrypt/live/gl.$NGINX_HOSTNAME/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/gl.$NGINX_HOSTNAME/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$GL_HOSTNAME.$DOMAIN_NAME/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$GL_HOSTNAME.$DOMAIN_NAME/privkey.pem;
 
     location /cable {
         proxy_pass  http://greenlight-server;
@@ -58,18 +58,20 @@ server {
             proxy_buffers              4 256k;
             proxy_busy_buffers_size    256k;
 
+            client_max_body_size 30m;
+
             rewrite ~/(.*)$ /$1 break;
     }
 }
 
-#### For <kc.$NGINX_HOSTNAME>
+#### For <$KC_HOSTNAME.$DOMAIN_NAME>
 
 upstream keycloak-server {
     server keycloak:8080;
 }
 
 server {
-    server_name kc.$NGINX_HOSTNAME;
+    server_name $KC_HOSTNAME.$DOMAIN_NAME;
 
     listen 80;
     listen [::]:80;
@@ -77,8 +79,8 @@ server {
     listen [::]:443;
 
     ## Configuration for Letsencrypt SSL Certificate
-    ssl_certificate /etc/letsencrypt/live/kc.$NGINX_HOSTNAME/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/kc.$NGINX_HOSTNAME/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$KC_HOSTNAME.$DOMAIN_NAME/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$KC_HOSTNAME.$DOMAIN_NAME/privkey.pem;
 
     location / {
         proxy_pass  http://keycloak-server;

--- a/data/nginx/sites.template-local
+++ b/data/nginx/sites.template-local
@@ -1,19 +1,19 @@
-#### For <gl.$NGINX_HOSTNAME>
+#### For <$GL_HOME.$DOMAIN_NAME>
 
 upstream greenlight-server {
-    server gl.$NGINX_HOSTNAME:3000;
+    server $GL_HOME.$DOMAIN_NAME:3000;
 }
 
 server {
-    server_name gl.$NGINX_HOSTNAME;
+    server_name $GL_HOME.$DOMAIN_NAME;
 
     listen 80;
     listen [::]:80;
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    ssl_certificate /etc/letsencrypt/live/gl.$NGINX_HOSTNAME/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/gl.$NGINX_HOSTNAME/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$GL_HOME.$DOMAIN_NAME/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$GL_HOME.$DOMAIN_NAME/privkey.pem;
 
     location /cable {
         proxy_pass  http://greenlight-server;
@@ -58,18 +58,20 @@ server {
             proxy_buffers              4 256k;
             proxy_busy_buffers_size    256k;
 
+            client_max_body_size 30m;
+
             rewrite ~/(.*)$ /$1 break;
     }
 }
 
-#### For <kc.$NGINX_HOSTNAME>
+#### For <$KC_HOME.$DOMAIN_NAME>
 
 upstream keycloak-server {
     server keycloak:8080;
 }
 
 server {
-    server_name kc.$NGINX_HOSTNAME;
+    server_name $KC_HOME.$DOMAIN_NAME;
 
     listen 80;
     listen [::]:80;
@@ -77,8 +79,8 @@ server {
     listen [::]:443;
 
     ## Configuration for Letsencrypt SSL Certificate
-    ssl_certificate /etc/letsencrypt/live/kc.$NGINX_HOSTNAME/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/kc.$NGINX_HOSTNAME/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$KC_HOME.$DOMAIN_NAME/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$KC_HOME.$DOMAIN_NAME/privkey.pem;
 
     location / {
         proxy_pass  http://keycloak-server;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./log/nginx/:/var/log/nginx
-      - ./data/nginx/sites-common:/etc/nginx/sites-common
+      - ./data/nginx/sites-common/:/etc/nginx/sites-common
       - ./data/nginx/sites.template-$SITES_TEMPLATE:/etc/nginx/sites.template
       - ./data/certbot/conf/:/etc/letsencrypt
       - ./data/certbot/www/:/var/www/certbot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,9 @@ services:
     volumes:
       - ./data/postgres/14/database_data:/var/lib/postgresql/data
     environment:
-      - PGUSER=postgres
-      - PGPASSWORD=password
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=password
-      - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
 
   redis:
     image: redis:6.2-alpine
@@ -23,7 +20,7 @@ services:
       - ./data/redis/database_data:/data
       - ./data/redis/conf/redis.conf.template:/usr/local/etc/redis/redis.conf.template
       - ./data/certbot/conf/:/etc/letsencrypt
-    command: /bin/sh -c "sed -e 's/$$HOSTNAME/redis.${DOMAIN_NAME:-xlab.blindside-dev.com}/' /usr/local/etc/redis/redis.conf.template > /usr/local/etc/redis/redis.conf && exec redis-server --appendonly yes"
+    command: /bin/sh -c "sed -e 's/$$HOSTNAME/redis.$DOMAIN_NAME/' /usr/local/etc/redis/redis.conf.template > /usr/local/etc/redis/redis.conf && exec redis-server --appendonly yes"
 
   nginx:
     image: nginx:1.23
@@ -32,18 +29,20 @@ services:
     volumes:
       - ./log/nginx/:/var/log/nginx
       - ./data/nginx/sites-common:/etc/nginx/sites-common
-      - ./data/nginx/sites.template-${SITES_TEMPLATE:-docker}:/etc/nginx/sites.template
+      - ./data/nginx/sites.template-$SITES_TEMPLATE:/etc/nginx/sites.template
       - ./data/certbot/conf/:/etc/letsencrypt
       - ./data/certbot/www/:/var/www/certbot
     ports:
       - "80:80"
       - "443:443"
     environment:
-      - NGINX_HOSTNAME=${DOMAIN_NAME:-xlab.blindside-dev.com}
+      - DOMAIN_NAME=$DOMAIN_NAME
+      - GL_HOSTNAME=$GL_HOSTNAME
+      - KC_HOSTNAME=$KC_HOSTNAME
     depends_on:
       - greenlight
       - keycloak
-    command: /bin/bash -c "envsubst '$$NGINX_HOSTNAME' < /etc/nginx/sites.template > /etc/nginx/conf.d/default.conf && while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g 'daemon off;'"
+    command: /bin/bash -c "envsubst '$$DOMAIN_NAME,$$GL_HOSTNAME,$$KC_HOSTNAME' < /etc/nginx/sites.template > /etc/nginx/conf.d/default.conf && while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g 'daemon off;'"
 
   certbot:
     image: certbot/certbot
@@ -53,10 +52,12 @@ services:
       - ./data/certbot/conf/:/etc/letsencrypt
       - ./data/certbot/www/:/var/www/certbot
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    depends_on:
+      - nginx
 
   greenlight:
     entrypoint: [bin/start]
-    image: ${GREENLIGHT_DOCKER_IMAGE:-bigbluebutton/greenlight:v3}
+    image: $GREENLIGHT_DOCKER_IMAGE
     container_name: greenlight
     restart: unless-stopped
     logging:
@@ -64,30 +65,27 @@ services:
     env_file: ./data/greenlight/.env
     volumes:
       - ./data/greenlight/bin/start:/usr/src/app/bin/start
+      - ./data/greenlight/storage:/usr/src/app/storage
     depends_on:
       - postgres
       - redis
 
   keycloak:
-    image: jboss/keycloak:16.1.1
+    image: $KEYCLOAK_DOCKER_IMAGE
     container_name: keycloak
     restart: unless-stopped
     environment:
       KEYCLOAK_USER: admin
-      KEYCLOAK_PASSWORD: adminadmin
+      KEYCLOAK_PASSWORD: $KEYCLOAK_PASSWORD
       DB_VENDOR: POSTGRES
       DB_ADDR: postgres
       DB_DATABASE: keycloakdb
       DB_USER: postgres
-      DB_PASSWORD: password
+      DB_PASSWORD: $POSTGRES_PASSWORD
       PROXY_ADDRESS_FORWARDING: "true"
     volumes:
       - ./data/certbot/conf/:/etc/letsencrypt
-      - ./data/certbot/conf/live/kc.${DOMAIN_NAME:-xlab.blindside-dev.com}/cert.pem:/etc/x509/https/tls.crt
-      - ./data/certbot/conf/live/kc.${DOMAIN_NAME:-xlab.blindside-dev.com}/privkey.pem:/etc/x509/https/tls.key
+      - ./data/certbot/conf/live/$KC_HOSTNAME.$DOMAIN_NAME/cert.pem:/etc/x509/https/tls.crt
+      - ./data/certbot/conf/live/$KC_HOSTNAME.$DOMAIN_NAME/privkey.pem:/etc/x509/https/tls.key
     depends_on:
       - postgres
-
-  #   docker run  --name keycloak --net greenlight-run_default -p 8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=adminadmin -e DB_VENDOR=POSTGRES -e DB_ADDR=postgres -e DB_DATABASE=keycloak -e DB_USER=postgres -e DB_PASSWORD=password jboss/keycloak:16.1.1
-  #   https://www.keycloak.org/docs/latest/server_installation/index.html#_setting-up-a-load-balancer-or-proxy
-  #   https://stackoverflow.com/questions/47181821/using-keycloak-behind-a-reverse-proxy-could-not-open-admin-loginpage-because-mi

--- a/dotenv
+++ b/dotenv
@@ -1,22 +1,29 @@
 ### Required when when specific repo or version (other than defaults) are needed
-# GREENLIGHT_DOCKER_IMAGE=bigbluebutton/greenlight:v3
+GREENLIGHT_DOCKER_IMAGE=bigbluebutton/greenlight:v3
 #
-### Optional for postgres when using docker-compose and want to change the default values
-# POSTGRES_USER=
-# POSTGRES_PASSWORD=
+### Keycloak image:
+KEYCLOAK_DOCKER_IMAGE=jboss/keycloak:16.1.1
 #
-### Optional for init-letsencrypt.sh when using certbot for generating signed SSL certificates
-# LETSENCRYPT_EMAIL=
-# LETSENCRYPT_STAGING=0
-#   Set to 1 if you're testing your setup to avoid hitting request limits
+### Used by init-letsencrypt.sh when generating SSL certificates.
+LETSENCRYPT_EMAIL=
+### Set to 1 if you're testing your setup to avoid hitting Letsencrypt rate limits
+LETSENCRYPT_STAGING=1
 #
-### Optional for development when using different profiles
-# SITES_TEMPLATE=docker
-# Examples:
-#   docker <default>
-#   local
+### The sites template nginx will use, for production leave as is.
+SITES_TEMPLATE=docker
 
-### Optional if the logs will be handled differently
-# RAILS_LOG_TO_STDOUT=true
-
+#
+### The Greenlight instance hostname that with the $DOMAIN_NAME forms its FQDN:
+GL_HOSTNAME=gl
+#
+### The Keycloak instance hostname that with the $DOMAIN_NAME forms its FQDN:
+KC_HOSTNAME=kc
+#
+### The public domain name that GL3 and keycloak will use, this has to be a valid domain name in the DNS network that resolves to your system public ip:
 DOMAIN_NAME=
+#
+### Postgres variables:
+POSTGRES_PASSWORD=
+#
+### Keycloak variables:
+KEYCLOAK_PASSWORD=

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -3,34 +3,24 @@
 ## Scrip based on https://github.com/wmnnd/nginx-certbot
 ## https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71
 
-if ! [ -x "$(command -v docker-compose)" ]; then
-  echo 'Error: docker-compose is not installed.' >&2
-  exit 1
-fi
-
-if [[ ! -f ./.env ]]; then
-  echo ".env file does not exist on your filesystem."
-  exit 1
-fi
-
-# Local .env
-if [ -f .env ]; then
-    # Load Environment Variables
-    export $(cat .env | grep -v '#' | sed 's/\r$//' | awk '/=/ {print $1}' )
-fi
-
-if [[ -z "$LETSENCRYPT_EMAIL" ]]; then
-  echo "Settung up an email for letsencrypt certificates is strongly recommended."
-  exit 1
-fi
+# Script functions declaration:
 
 usage() {
-  echo -e "Initializes letsencrypt certificates for Nginx proxy container\n"
   echo -e "Usage: $0 [-z|-r|-h]\n"
+  echo "$0 is a simple script that automates the issuing of letsencrypt certificates for Greenlight."
   echo "  -n|--non-interactive  Enable non interactive mode"
   echo "  -r|--replace          Replace existing certificates without asking"
   echo "  -h|--help             Show usage information"
-  exit 1
+}
+
+docker_compose() {
+  if [[ $composePlugin == 1 ]]; then
+    docker compose "$@"
+  else
+    docker-compose "$@"
+  fi
+
+  return $?
 }
 
 interactive=1
@@ -41,63 +31,129 @@ do
     case "$1" in
         -n|--non-interactive) interactive=0;shift;;
         -r|--replace) replaceExisting=1;shift;;
-        -h|--help) usage;;
-        -*) echo "Unknown option: \"$1\"\n";usage;;
-        *) echo "Script does not accept arguments\n";usage;;
+        -h|--help) usage;exit;;
+        -*) >&2 echo -e "Unknown option: \"$1\" ⛔ \n";usage;exit 1;;
+        *) >&2 echo -e "Script does not accept arguments ⛔ \n";usage;exit 1;;
     esac
 done
 
-echo $URL_HOST
+# Loading and checking Environment Variables:
+echo "## Checking enviroment ⏳"
 
-domains=($URL_HOST)
+if [[ ! -f ./.env ]]; then
+  >&2 echo ".env file does not exist on your filesystem ⛔"
+  exit 1
+fi
+
+export $(cat .env | grep -v '#' | sed 's/\r$//' | awk '/=/ {print $1}' )
+
+if [[ -z "$LETSENCRYPT_EMAIL" ]]; then
+  >&2 echo "Required \$LETSENCRYPT_EMAIL variable is not set in .env ⛔"
+  >&2 echo "Setting up an email for letsencrypt certificates is strongly recommended ❗"
+  exit 1
+fi
+
+if [[ -z $DOMAIN_NAME ]]; then
+  >&2 echo "Required \$DOMAIN_NAME variable is not set in .env ⛔"
+  exit 1
+fi
+
+if [[ -z $GL_HOSTNAME ]] && [[ -z $KC_HOSTNAME ]]; then
+  >&2 echo "NO FQDN is set ⛔"
+  >&2 echo "At least one FQDN should be provided to generate a certificate for ❗"
+  exit 1
+fi
+
+# Checking installed compose version: 
+if docker compose version &> /dev/null; then
+  composePlugin=1
+  echo "-> Detected docker compose plugin ✔"
+elif docker-compose version &> /dev/null; then
+  composePlugin=0
+  echo "-> Unable to detect docker compose plugin 🛑"
+  echo "-> Detected docker-compose utility ✔"
+else
+  >&2 echo 'No "docker-compose" or "docker compose" is installed ⛔'
+  exit 1
+fi
+echo "-> Enviroment checked ✔"
+echo
+
+
+echo "## Preparing enviroment ⏳"
+
+if [[ ! -z $GL_HOSTNAME ]]; then
+  GL_FQDN="$GL_HOSTNAME.$DOMAIN_NAME"
+fi
+
+if [[ ! -z $KC_HOSTNAME ]]; then
+  KC_FQDN="$KC_HOSTNAME.$DOMAIN_NAME"
+fi
+
+IFS=' '
+domains="$GL_FQDN $KC_FQDN"
+domains=($domains)
 rsa_key_size=4096
-data_path="./data/certbot"
+data_path="./data/certbot/conf"
+web_root="./data/certbot/www"
 email="$LETSENCRYPT_EMAIL" # Adding a valid address is strongly recommended.
-staging=${LETSENCRYPT_STAGING:-0}
+staging=${LETSENCRYPT_STAGING:-1}
+
+echo "-> Prepared enviroment successfully ✔"
+echo "-> Attempting to issue Let's Encrypt certificates for ${domains[@]} for the email address of '$email' ⏳"
+echo "-> Let's encrypt certificate files will be stored under '$data_path' ❕"
+echo "-> '$web_root' will be the web root for the HTTP-01 ACME challenge ❕"
+echo
 
 if [ -d "$data_path" ] && [ "$replaceExisting" -eq 0 ]; then
     if [ "$interactive" -eq 0 ]; then
-      echo "Certificates already exist."
+      echo "-> Certificates already exist under '$data_path' 🛑"
       exit
     fi
 
-    read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+    read -p "Existing certificates data found. Continue and replace ? (y/N) ❔ " decision
     if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
       exit
     fi
 fi
 
-if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
-  echo "### Downloading recommended TLS parameters ..."
-  mkdir -p "$data_path/conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+mkdir -p "$data_path"
+mkdir -p "$web_root"
+
+# Load TLS parameters:
+if [ ! -e "$data_path/options-ssl-nginx.conf" ] || [ ! -e "$data_path/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended nginx TLS parameters ⏳"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/ssl-dhparams.pem"
+  echo "-> Downloaded recommended nginx  TLS parameters ✔"
   echo
 fi
 
-echo "### Creating dummy certificate for $domains ..."
+# Chicken egg problem:
+echo "### Creating dummy certificates for ${domains[@]} ⏳"
 path="/etc/letsencrypt/live/$domains"
-mkdir -p "$data_path/conf/live/$domains"
-docker-compose run --rm --entrypoint "\
+mkdir -p "$data_path/live/$domains"
+
+docker_compose run --rm --entrypoint "\
   openssl req -x509 -nodes -newkey rsa:2048 -days 1\
     -keyout '$path/privkey.pem' \
     -out '$path/fullchain.pem' \
     -subj '/CN=localhost'" certbot
 echo
 
-echo "### Starting nginx ..."
-docker-compose up --force-recreate -d nginx
+echo "### Starting nginx ⏳"
+docker_compose up --force-recreate -d nginx
 echo
 
-echo "### Deleting dummy certificate for $domains ..."
-docker-compose run --rm --entrypoint "\
+echo "### Deleting dummy certificate for ${domains[@]} ⏳"
+docker_compose run --rm --entrypoint "\
   rm -Rf /etc/letsencrypt/live/$domains && \
   rm -Rf /etc/letsencrypt/archive/$domains && \
   rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
 echo
 
 
-echo "### Requesting Let's Encrypt certificate for $domains ..."
+echo "Requesting Let's Encrypt certificates for ${domains[@]} for the email address of '$email' ⏳"
 #Join $domains to -d args
 domain_args=""
 for domain in "${domains[@]}"; do
@@ -113,7 +169,7 @@ esac
 # Enable staging mode if needed
 if [ $staging != "0" ]; then staging_arg="--staging"; fi
 
-docker-compose run --rm --entrypoint "\
+docker_compose run --rm --entrypoint "\
   certbot certonly --webroot -w /var/www/certbot \
     $staging_arg \
     $([ "$interactive" -ne 1 ] && echo '--non-interactive') \
@@ -126,4 +182,4 @@ docker-compose run --rm --entrypoint "\
 echo
 
 echo "### Reloading nginx..."
-docker-compose exec $([ "$interactive" -ne 1 ] && echo "-T") nginx nginx -s reload
+docker_compose exec $([ "$interactive" -ne 1 ] && echo "-T") nginx nginx -s reload


### PR DESCRIPTION
The `init-letsencrypt.sh` script requires having **docker and compose** installed  as pointed in the docs.

However, the scripts were written and will be used in time in which the docker maintainers are supporting two compose utilities: the compose plugin and `docker-compose` command. 

Both utilities works for the script concern, therefore to avoid having a dependency on which utility to install the scripts were meant to be compatible with whatever installed on the system.

However, that feature was buggy and this PR introduced a fix.